### PR TITLE
Webhook Lambda for Monitoring

### DIFF
--- a/webhook_monitor/.eslintrc.yml
+++ b/webhook_monitor/.eslintrc.yml
@@ -1,0 +1,11 @@
+env:
+  browser: true
+  commonjs: true
+  es6: true
+extends: 'eslint:recommended'
+globals:
+  Atomics: readonly
+  SharedArrayBuffer: readonly
+parserOptions:
+  ecmaVersion: 2018
+rules: {}

--- a/webhook_monitor/.gitignore
+++ b/webhook_monitor/.gitignore
@@ -1,0 +1,6 @@
+.aws
+.aws-sam
+deploy.yaml
+node_modules
+package-lock.json
+samconfig.toml

--- a/webhook_monitor/package.json
+++ b/webhook_monitor/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "alma_webhook_monitor",
+  "version": "1.0.0",
+  "description": "Receive and monitor Alma Webhooks with Datadog.",
+  "author": "Trey Pendragon",
+  "license": "Apache-2.0",
+  "dependencies": {},
+  "devDependencies": {
+    "jest": "^25.3.0"
+  },
+  "scripts": {
+    "test": "jest"
+  }
+}

--- a/webhook_monitor/package.json
+++ b/webhook_monitor/package.json
@@ -6,6 +6,7 @@
   "license": "Apache-2.0",
   "dependencies": {},
   "devDependencies": {
+    "eslint": "^6.8.0",
     "jest": "^25.3.0"
   },
   "scripts": {

--- a/webhook_monitor/src/index.js
+++ b/webhook_monitor/src/index.js
@@ -21,8 +21,7 @@ const requestHandler = async function(event) {
   console.log("Message received: " + JSON.stringify(event.body));
   const secret = await getSecret()
   if(validateSignature(event, secret)) {
-    const request = JSON.stringify(event.body);
-    sendDistributionMetric('alma.webhook.action', request.action, 'environment:sandbox');
+    sendDistributionMetric('alma.webhook.action', 1, 'environment:sandbox', `action:${event.body.action}`);
     return JSON.stringify(event.body)
   } else {
     throw "Signature Invalid"

--- a/webhook_monitor/src/index.js
+++ b/webhook_monitor/src/index.js
@@ -1,6 +1,29 @@
-const requestHandler = async function(event, context) {
+const crypto = require('crypto');
+const AWS = require('aws-sdk');
+const client = new AWS.SecretsManager();
+const validateSignature = function(event, secret) {
+  var body = event.body;
+  var hash = crypto.createHmac('SHA256', secret)
+             .update(JSON.stringify(body))
+             .digest('base64');
+  return hash == event.signature
+}
+
+async function getSecret() {
+  return client.getSecretValue({SecretId: "alma/sandbox/webhookSecret"}).promise().then((data) => {
+    return JSON.parse(data.SecretString).key
+  }).catch((err) => {
+    console.log(err)
+  })
+}
+const requestHandler = async function(event) {
   console.log("Message received: " + JSON.stringify(event.body));
-  return JSON.stringify(event.body)
+  const secret = await getSecret()
+  if(validateSignature(event, secret)) {
+    return JSON.stringify(event.body)
+  } else {
+    throw "Signature Invalid"
+  }
 }
 
 exports.handler = requestHandler

--- a/webhook_monitor/src/index.js
+++ b/webhook_monitor/src/index.js
@@ -1,0 +1,6 @@
+const requestHandler = async function(event, context) {
+  console.log("Message received: " + JSON.stringify(event.body));
+  return JSON.stringify(event.body)
+}
+
+exports.handler = requestHandler

--- a/webhook_monitor/template.yml
+++ b/webhook_monitor/template.yml
@@ -10,9 +10,6 @@ Metadata:
     SemanticVersion: 1.0.0
     SourceCodeUrl: https://github.com/pulibrary/alma_experimentation
 Parameters:
-  Secret:
-    Type: String
-    Description: Alma Webhook Secret
   StageName:
     Type: String
     Description: Name of the API stage to be deployed
@@ -67,12 +64,18 @@ Resources:
                   description: "200 response"
                   schema:
                     $ref: "#/definitions/Empty"
+                "401":
+                  description: "Invalid Secret"
+                  schema:
+                    $ref: "#/definitions/Empty"
               x-amazon-apigateway-integration:
                 uri:
                   Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${WebhookReceiver.Arn}/invocations"
                 responses:
                   default:
                     statusCode: "200"
+                  "Signature Invalid":
+                    statusCode: 401
                 passthroughBehavior: "when_no_match"
                 httpMethod: "POST"
                 requestTemplates:
@@ -94,9 +97,13 @@ Resources:
         - 'arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node12-x:22'
       Policies:
         - AWSLambdaExecute
+        - Version: "2012-10-17"
+          Statement: 
+            - Effect: "Allow"
+              Action: "secretsmanager:GetSecretValue"
+              Resource: "*"
       Environment:
         Variables:
-          almaSecret: !Sub "${Secret}"
           DD_FLUSH_TO_LOG: True
       Events:
         PostWebhook:

--- a/webhook_monitor/template.yml
+++ b/webhook_monitor/template.yml
@@ -59,6 +59,52 @@ Resources:
                   application/json: "{ \"statusCode\": 200}"
                 passthroughBehavior: "when_no_match"
                 type: "mock"
+            post:
+              produces:
+                - "application/json"
+              responses:
+                "200":
+                  description: "200 response"
+                  schema:
+                    $ref: "#/definitions/Empty"
+              x-amazon-apigateway-integration:
+                uri:
+                  Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${WebhookReceiver.Arn}/invocations"
+                responses:
+                  default:
+                    statusCode: "200"
+                passthroughBehavior: "when_no_match"
+                httpMethod: "POST"
+                requestTemplates:
+                  application/json: >-
+                    #set($inputRoot = $input.path('$')) {
+                      "signature": "$input.params().header.get('X-Exl-Signature')",
+                      "body": $input.json('$')
+                    }
+                type: "aws"
+  WebhookReceiver:
+    Type: "AWS::Serverless::Function"
+    Properties:
+      Runtime: nodejs12.x
+      Handler: index.handler
+      MemorySize: 512
+      Timeout: 30
+      CodeUri: ./src
+      Layers:
+        - 'arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node12-x:22'
+      Policies:
+        - AWSLambdaExecute
+      Environment:
+        Variables:
+          almaSecret: !Sub "${Secret}"
+          DD_FLUSH_TO_LOG: True
+      Events:
+        PostWebhook:
+          Type: Api
+          Properties:
+            Path: /webhooks
+            Method: POST
+            RestApiId: !Ref APIGateway
 Outputs:
   Endpoint:
     Description: Endpoint URL

--- a/webhook_monitor/template.yml
+++ b/webhook_monitor/template.yml
@@ -1,0 +1,65 @@
+Transform: "AWS::Serverless-2016-10-31"
+Metadata:
+  AWS::ServerlessRepo::Application:
+    Name: alma-webhook-monitor
+    Description: Receive webhooks from Alma and log them.
+    Author: tpendragon
+    SpdxLicenseId: Apache-2.0
+    Labels: ["alma", "monitoring"]
+    HomePageUrl: https://github.com/pulibrary/alma_experimentation
+    SemanticVersion: 1.0.0
+    SourceCodeUrl: https://github.com/pulibrary/alma_experimentation
+Parameters:
+  Secret:
+    Type: String
+    Description: Alma Webhook Secret
+  StageName:
+    Type: String
+    Description: Name of the API stage to be deployed
+    Default: latest
+Resources:
+  APIGateway:
+    Type: "AWS::Serverless::Api"
+    Properties:
+      Name: !Sub "${AWS::StackName}-api"
+      StageName: !Sub "${StageName}"
+      EndpointConfiguration: "REGIONAL"
+      Cors:
+        AllowMethods: "'GET','POST'"
+        AllowOrigin: "'*'"
+      DefinitionBody:
+        swagger: "2.0"
+        info:
+          version: "2018-12-14T18:28:00Z"
+        schemes:
+          - "http"
+          - "https"
+        paths:
+          /webhooks:
+            get:
+              produces:
+                - "application/json"
+              parameters:
+                - name: "challenge"
+                  in: "query"
+                  required: true
+                  type: "string"
+              responses:
+                "200":
+                  description: "200 response"
+                  schema:
+                    $ref: "#/definitions/Empty"
+              x-amazon-apigateway-integration:
+                responses:
+                  default:
+                    statusCode: 200
+                    responseTemplates:
+                      application/json: "{\"challenge\":\"$input.params('challenge')\"}"
+                requestTemplates:
+                  application/json: "{ \"statusCode\": 200}"
+                passthroughBehavior: "when_no_match"
+                type: "mock"
+Outputs:
+  Endpoint:
+    Description: Endpoint URL
+    Value: !Sub "https://${APIGateway}.execute-api.${AWS::Region}.amazonaws.com/${APIGateway.Stage}/webhooks"

--- a/webhook_monitor/test.rb
+++ b/webhook_monitor/test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rest-client'
+require 'base64'
+require 'securerandom'
+require 'json'
+
+KEY = '123'
+URL = 'https://4ypja0mlne.execute-api.us-east-1.amazonaws.com/staging/webhooks'
+
+to = ARGV[0]
+msg = ARGV[1]
+
+abort 'Invalid number of parameters' unless to && msg
+
+puts "Challenging server at #{URL}"
+challenge = SecureRandom.uuid
+abort "Server didn't respond to challenge" unless
+    RestClient.get("#{URL}?challenge=#{challenge}")
+              .include? challenge
+
+req = {
+  action: 'sms',
+  sms: {
+    msg: msg,
+    to: to
+  }
+}.to_json
+
+digest = OpenSSL::Digest.new('sha256')
+hmac = Base64.encode64(OpenSSL::HMAC.digest(digest, KEY, req))
+
+puts 'Posting to server'
+begin
+  RestClient.post URL,
+                  req,
+                  content_type: :json,
+                  'X-Exl-Signature' => hmac
+  puts 'Done'
+rescue StandardError => e
+  puts "ERROR: #{e.http_code} #{e.response}"
+end

--- a/webhook_monitor/test.rb
+++ b/webhook_monitor/test.rb
@@ -30,6 +30,7 @@ req = {
 digest = OpenSSL::Digest.new('sha256')
 hmac = Base64.encode64(OpenSSL::HMAC.digest(digest, KEY, req))
 
+puts req
 puts 'Posting to server'
 begin
   RestClient.post URL,

--- a/webhook_monitor/test.rb
+++ b/webhook_monitor/test.rb
@@ -33,10 +33,11 @@ hmac = Base64.encode64(OpenSSL::HMAC.digest(digest, KEY, req))
 puts req
 puts 'Posting to server'
 begin
-  RestClient.post URL,
+  output = RestClient.post URL,
                   req,
                   content_type: :json,
                   'X-Exl-Signature' => hmac
+  puts output
   puts 'Done'
 rescue StandardError => e
   puts "ERROR: #{e.http_code} #{e.response}"


### PR DESCRIPTION
This is the configuration for the webhook lambda we can use to monitor. It's been set up in the sandbox.

There's a DataDog Dashboard for tracking webhooks received by actions here: https://app.datadoghq.com/dashboard/h8i-8uj-25j/alma-webhook-status?from_ts=1588799410114&live=true&to_ts=1588803010114

It should update pretty quickly. It looks like the following:

![Screen Shot 2020-05-06 at 3 13 07 PM](https://user-images.githubusercontent.com/2806645/81233716-1d7b7b00-8fac-11ea-9e15-2ec840742eed.png)


(the sms hook isn't real, that's from the test script.)

Work towards https://github.com/pulibrary/marc_liberation/issues/645